### PR TITLE
fix: add s3os object key

### DIFF
--- a/console/src/composables/use-migrate-from-halo.ts
+++ b/console/src/composables/use-migrate-from-halo.ts
@@ -585,6 +585,7 @@ class S3OSSAttachmentTask extends AbstractAttachmentTask {
       metadata: {
         name: this.item.id + "",
         annotations: {
+          "s3os.plugin.halo.run/object-key": `${this.item.fileKey}`,
           "storage.halo.run/external-link": `${this.item.path}`,
           "storage.halo.run/suffix": `${this.item.suffix}`,
           "storage.halo.run/width": `${this.item.width}`,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

迁移 s3 附件时，增加 object key

#### Which issue(s) this PR fixes:

Fixes #24 

#### Special notes for your reviewer:

查看迁移到 s3 的附件是否具有 `s3os.plugin.halo.run/object-key` annotations 即可

#### Does this PR introduce a user-facing change?

```release-note
迁移 s3 附件时增加 object key 字段
``` 
