### PR TITLE
fix: resolve issue of displaying attachment storage policy when no attachments are present

### DIFF
--- a/console/src/views/MigrateView.vue
+++ b/console/src/views/MigrateView.vue
@@ -160,7 +160,8 @@ const stepItems: Step[] = [
       disabledMessage: "未设置附件存储策略",
     },
     visible: computed(() => {
-      return migrateData.value?.attachments != undefined;
+      const attachments = migrateData.value?.attachments;
+      return attachments && attachments.length > 0;
     }),
   },
   {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

解决在没有附件时仍旧会显示附件存储策略的问题

#### How to test it?

测试使用 wordpress 导入，导入一个不包含附件的文件。查看是否会出现 `选择附件存储策略` 的步骤。

#### Which issue(s) this PR fixes:

Fixes #37 

#### Does this PR introduce a user-facing change?
```release-note
解决在没有附件时仍旧会显示附件存储策略的问题
```
