### PR TITLE
refactor: remove role template

### DIFF
--- a/console/env.d.ts
+++ b/console/env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="unplugin-icons/types/vue" />
 
 declare module "*.vue" {
   import Vue from "vue";

--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -1,6 +1,6 @@
 import { definePlugin } from "@halo-dev/console-shared";
 import { markRaw } from "vue";
-import SolarTransferHorizontalBoldDuotone from '~icons/solar/transfer-horizontal-bold-duotone';
+import SolarTransferHorizontalBoldDuotone from "~icons/solar/transfer-horizontal-bold-duotone";
 import "./styles/tailwind.css";
 import MigrateView from "./views/MigrateView.vue";
 
@@ -18,7 +18,7 @@ export default definePlugin({
             meta: {
               title: "迁移",
               searchable: true,
-              permissions: ["plugin:PluginMigrate:migrate"],
+              permissions: ["*"],
               menu: {
                 name: "迁移",
                 group: "tool",

--- a/src/main/resources/extensions/roleTemplate.yaml
+++ b/src/main/resources/extensions/roleTemplate.yaml
@@ -9,8 +9,10 @@ metadata:
     rbac.authorization.halo.run/display-name: "Migration"
     rbac.authorization.halo.run/ui-permissions: |
       ["plugin:PluginMigrate:migrate"]
+  # This role template file will be removed in future versions
+  deletionTimestamp: 2024-02-18T08:27:41.257531Z
 rules:
-  - apiGroups: [ "plugin.halo.run" ]
-    resources: [ "plugins/rss-parse" ]
-    resourceNames: [ "PluginMigrate" ]
-    verbs: [ "create" ]
+  - apiGroups: ["plugin.halo.run"]
+    resources: ["plugins/rss-parse"]
+    resourceNames: ["PluginMigrate"]
+    verbs: ["create"]


### PR DESCRIPTION
因为此插件的定位，基本上只有超级管理员才有使用的可能，所以建议直接移除 Role Template 定义，并且将 Console 入口的 UI 权限限制为超级管理员。

```release-note
修改插件的权限逻辑，改为仅面向超级管理员可用。
```