### PR TITLE
refactor: auto-generate excerpt if it's empty

### DIFF
--- a/console/src/modules/wordpress/use-wordpress-data-parser.ts
+++ b/console/src/modules/wordpress/use-wordpress-data-parser.ts
@@ -160,6 +160,9 @@ export function useWordPressDataParser(
           });
           return attachment?.["wp:attachment_url"];
         })[0];
+
+      const excerpt = post["excerpt:encoded"];
+
       return {
         postRequest: {
           post: {
@@ -174,8 +177,8 @@ export function useWordPressDataParser(
               visible: "PUBLIC",
               priority: 0,
               excerpt: {
-                autoGenerate: false,
-                raw: post["excerpt:encoded"],
+                autoGenerate: !excerpt,
+                raw: excerpt,
               },
               categories: categoryIds,
               tags: tagIds,


### PR DESCRIPTION
在 WordPress 迁移时，如果 excerpt 为空，则将 `autoGenerate` 设置为 true。

/kind feature

```release-note
WordPress 迁移时，支持自动生成文章摘要。
```