### PR TITLE
fix: resolve issue where WordPress import fails with a single tag

### DIFF
--- a/console/src/modules/wordpress/use-wordpress-data-parser.ts
+++ b/console/src/modules/wordpress/use-wordpress-data-parser.ts
@@ -26,6 +26,7 @@ export function useWordPressDataParser(
         const isArrayPath = [
           "rss.channel.item",
           "rss.channel.wp:category",
+          "rss.channel.wp:tag",
           "rss.channel.item.category",
           "rss.channel.item.wp:postmeta",
           "rss.channel.item.wp:comment",


### PR DESCRIPTION
修复 WordPress 导入仅有一个标签时，无法下一步的问题。

/kind bug

```release-note
修复 WordPress 导入仅有一个标签时，无法下一步的问题。
```